### PR TITLE
Configure buildah to use CI mirror

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -76,7 +76,7 @@ presubmits:
               memory: 3Gi
 
   - name: pre-kubermatic-kubelet-test-building-v1.20
-    run_if_changed: "^(hack|v1.20)/"
+    run_if_changed: "^(v1.20)/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubelet.git"
     labels:
@@ -100,7 +100,7 @@ presubmits:
               memory: 3Gi
 
   - name: pre-kubermatic-kubelet-test-building-v1.21
-    run_if_changed: "^(hack|v1.21)/"
+    run_if_changed: "^(v1.21)/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubelet.git"
     labels:
@@ -124,7 +124,7 @@ presubmits:
               memory: 3Gi
 
   - name: pre-kubermatic-kubelet-test-building-v1.22
-    run_if_changed: "^(hack|v1.22)/"
+    run_if_changed: "^(v1.22)/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubelet.git"
     labels:
@@ -148,7 +148,7 @@ presubmits:
               memory: 3Gi
 
   - name: pre-kubermatic-kubelet-test-building-v1.23
-    run_if_changed: "^(hack|v1.23)/"
+    run_if_changed: "^(v1.23)/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubelet.git"
     labels:

--- a/hack/ci/build-images.sh
+++ b/hack/ci/build-images.sh
@@ -24,6 +24,20 @@ if [ -z "${MINOR_VERSION:-}" ]; then
   exit 1
 fi
 
+if [ -n "${DOCKER_REGISTRY_MIRROR_ADDR:-}" ]; then
+  # remove "http://" or "https://" prefix
+  mirror="$(echo "$DOCKER_REGISTRY_MIRROR_ADDR" | awk -F// '{print $NF}')"
+
+  echodate "Configuring registry mirror for docker.io ..."
+
+  cat <<EOF > /etc/containers/registries.conf.d/mirror.conf
+[[registry]]
+prefix = "docker.io"
+insecure = true
+location = "$mirror"
+EOF
+fi
+
 echodate "Building Docker image for $MINOR_VERSION ..."
 cd "$MINOR_VERSION"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to ensure buildah knows about our mirror.
