### PR TITLE
Bump base image to bookworm-v1.0.0

### DIFF
--- a/v1.24/baseimage
+++ b/v1.24/baseimage
@@ -1,1 +1,1 @@
-bullseye-v1.5.7
+bookworm-v1.0.0

--- a/v1.25/baseimage
+++ b/v1.25/baseimage
@@ -1,1 +1,1 @@
-bullseye-v1.5.7
+bookworm-v1.0.0

--- a/v1.26/baseimage
+++ b/v1.26/baseimage
@@ -1,1 +1,1 @@
-bullseye-v1.5.7
+bookworm-v1.0.0

--- a/v1.27/baseimage
+++ b/v1.27/baseimage
@@ -1,1 +1,1 @@
-bullseye-v1.5.7
+bookworm-v1.0.0

--- a/v1.28/baseimage
+++ b/v1.28/baseimage
@@ -1,1 +1,1 @@
-bullseye-v1.5.7
+bookworm-v1.0.0


### PR DESCRIPTION
**What this PR does / why we need it**:

All supported Kubernetes releases (v1.24-v1.28) are using Go 1.20.5 or 1.19.10. Docker images for those Go versions are based on Debian 12 (bookworm). Hence, Kubernetes bumped their base images to bookworm as well (https://github.com/kubernetes/release/issues/3128).

This PR proposes doing the same for this repo to unblock #169 

/assign @xrstf 