### PR TITLE
Switch from Buildah to buildx

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -35,7 +35,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.21.0
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/build-images.sh
           env:
@@ -59,7 +59,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.21.0
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/build-images.sh
           env:
@@ -83,7 +83,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.21.0
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/build-images.sh
           env:
@@ -107,7 +107,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.21.0
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/build-images.sh
           env:
@@ -131,7 +131,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.21.0
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/build-images.sh
           env:
@@ -155,7 +155,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.21.0
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/build-images.sh
           env:
@@ -179,7 +179,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.21.0
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/build-images.sh
           env:
@@ -203,7 +203,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.21.0
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/build-images.sh
           env:
@@ -227,7 +227,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.21.0
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/build-images.sh
           env:
@@ -251,7 +251,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.21.0
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/build-images.sh
           env:
@@ -275,7 +275,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.21.0
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/build-images.sh
           env:


### PR DESCRIPTION
**What this PR does / why we need it**:
In KKP / KubeOne we recently switched to buildx. This PR does the same for this repo so we can eventually get rid of Buildah entirely in our kubermatic/build image.
